### PR TITLE
Fix missing require

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -3,7 +3,6 @@ require 'redmine'
 require File.dirname(__FILE__) + '/lib/westaco_versions_hook.rb'
 require File.dirname(__FILE__) + '/lib/westaco_versions_issue_patch.rb'
 require File.dirname(__FILE__) + '/lib/westaco_versions_queries_controller_patch.rb'
-require File.dirname(__FILE__) + '/lib/westaco_versions_controller_patch.rb'
 require File.dirname(__FILE__) + '/lib/westaco_version_patch.rb'
 
 Rails.logger.info 'Starting Westaco Versions Plugin for Redmine'


### PR DESCRIPTION
## Summary
- remove require for missing westaco_versions_controller_patch.rb

## Testing
- `ruby -c init.rb`


------
https://chatgpt.com/codex/tasks/task_e_688266c9c6448332b5b59d4522b7db36