### PR TITLE
Update migration versions for Rails 6

### DIFF
--- a/db/migrate/001_add_versions_dates.rb
+++ b/db/migrate/001_add_versions_dates.rb
@@ -1,4 +1,4 @@
-class AddVersionsDates < Rails::VERSION::MAJOR < 5 ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
+class AddVersionsDates < Rails::VERSION::MAJOR < 5 ? ActiveRecord::Migration : ActiveRecord::Migration[6.1]
 
     def self.up
         add_column :versions, :start_date, :date

--- a/db/migrate/002_add_versions_status_index.rb
+++ b/db/migrate/002_add_versions_status_index.rb
@@ -1,4 +1,4 @@
-class AddVersionsStatusIndex < Rails::VERSION::MAJOR < 5 ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
+class AddVersionsStatusIndex < Rails::VERSION::MAJOR < 5 ? ActiveRecord::Migration : ActiveRecord::Migration[6.1]
 
     def self.up
         add_index :versions, :status

--- a/db/migrate/003_populate_versions_dates.rb
+++ b/db/migrate/003_populate_versions_dates.rb
@@ -1,4 +1,4 @@
-class PopulateVersionsDates < Rails::VERSION::MAJOR < 5 ? ActiveRecord::Migration : ActiveRecord::Migration[4.2]
+class PopulateVersionsDates < Rails::VERSION::MAJOR < 5 ? ActiveRecord::Migration : ActiveRecord::Migration[6.1]
 
     def self.up
         Version.where(:closed_on => nil, :status => 'closed')


### PR DESCRIPTION
## Summary
- update migrations to target ActiveRecord 6.1

## Testing
- `bundle exec rake db:migrate` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_688266cb1a408332b2c86faf8868186c