### PR TITLE
Fix roadmap list link helpers

### DIFF
--- a/app/views/roadmap/_list.html.erb
+++ b/app/views/roadmap/_list.html.erb
@@ -16,7 +16,7 @@
               <span class="name"><%= version_column_label(@query.group_by_column.name, group_name) %></span>
               <% if group_count %><span class="badge badge-count count"><%= group_count %></span><% end %>
               <span class="totals"><%= group_totals %></span>
-              <%= link_to_function("#{l(:button_collapse_all)}/#{l(:button_expand_all)}", 'toggleAllRowGroups(this)', :class => 'toggle-all') %>
+              <%= link_to("#{l(:button_collapse_all)}/#{l(:button_expand_all)}", '#', :class => 'toggle-all', :onclick => 'toggleAllRowGroups(this); return false;') %>
             </td>
           </tr>
         <% end %>


### PR DESCRIPTION
## Summary
- replace deprecated `link_to_function` helper in `roadmap/_list.html.erb`

## Testing
- `bundle exec rake` *(fails: Could not locate Gemfile)*

------
https://chatgpt.com/codex/tasks/task_e_688266cbba6c83328d986501a997dec4