### PR TITLE
Fix timezone usage for version timestamps

### DIFF
--- a/app/views/versions/_overview.html.erb
+++ b/app/views/versions/_overview.html.erb
@@ -2,7 +2,7 @@
 <%= render inline: overview_file, locals: { version: version } %>
 <% version_changes_status = version.version_changes.status %>
 <% version_status_changes_timeline = version.version_status_changes_timeline %>
-<% version_status_changes_timeline << (Time.now - (version.last_version_status_change_in_time))/3600 %>
+<% version_status_changes_timeline << (Time.zone.now - (version.last_version_status_change_in_time))/3600 %>
 
 <div class="westaco-version-changes">
   <span><%= l(:field_status) %></span>

--- a/lib/westaco_version_patch.rb
+++ b/lib/westaco_version_patch.rb
@@ -34,7 +34,7 @@ module WestacoVersionPatch
             before_save :update_closed_on
             after_save :create_version_change
             after_create do |version|
-                time_now = Time.now
+                time_now = Time.zone.now
 
                 version.version_changes.create(
                     :project => version.project,
@@ -135,7 +135,7 @@ module WestacoVersionPatch
             end
 
             if closed?
-                self.closed_on = Time.now if new_record? || status_changed?
+                self.closed_on = Time.zone.now if new_record? || status_changed?
             else
                 self.closed_on = nil if closed_on
             end
@@ -143,7 +143,7 @@ module WestacoVersionPatch
 
         def create_version_change
             if self.status_has_been_changed
-                time_now = Time.now
+                time_now = Time.zone.now
 
                 self.version_changes.create(
                     :project => project,


### PR DESCRIPTION
## Summary
- use `Time.zone.now` for all timestamps

## Testing
- `ruby -c lib/westaco_version_patch.rb`


------
https://chatgpt.com/codex/tasks/task_e_688266cdd3f883329c10d3ab1cf1559a