### PR TITLE
Remove obsolete unloadable calls

### DIFF
--- a/lib/westaco_version_patch.rb
+++ b/lib/westaco_version_patch.rb
@@ -3,7 +3,6 @@ module WestacoVersionPatch
     def self.included(base)
         base.send(:include, InstanceMethods)
         base.class_eval do
-            unloadable
 
             belongs_to :version_status, :foreign_key => :status, :primary_key => :key
             has_many :version_changes, :dependent => :delete_all

--- a/lib/westaco_versions_issue_patch.rb
+++ b/lib/westaco_versions_issue_patch.rb
@@ -3,7 +3,6 @@ module WestacoVersionsIssuePatch
     def self.included(base)
         base.send(:include, InstanceMethods)
         base.class_eval do
-            unloadable
 
             after_save :update_version_start_date, :if => Proc.new { |issue|
                 Rails::VERSION::MAJOR < 5 || (Rails::VERSION::MAJOR == 5 && Rails::VERSION::MINOR < 1) ?


### PR DESCRIPTION
## Summary
- drop `unloadable` from issue and version patches

These calls cause undefined method errors under Rails 6+.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688266ce53bc833282639e1b0d4b18c9